### PR TITLE
Added code for printing error messages in standard error

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,2 @@
+Are you nobody, too?
+How dreary to be somebody!

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,12 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     let config = Config::build(&args).unwrap_or_else(|err| {
-        println!("Problem parsing arguments: {err}");
+        eprintln!("Problem parsing arguments: {err}");
         process::exit(1);
     });
 
     if let Err(e) = minigrep::run(config) {
-        println!("Application error: {e}");
+        eprintln!("Application error: {e}");
         process::exit(1);
     }
 }


### PR DESCRIPTION
Replaced the println! macros with eprintln! in main.rs, which prints error messages in standard error instead of standard output. The 'output.txt' file was created by running 'cargo run -- to poem.txt > output.txt'.